### PR TITLE
Build: CI/CD improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      dotnet:
+        patterns:
+          - "*" # Prefer a single PR per solution update.
+
+  # NuGet packages
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 25
+    groups:
+      dotnet:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'cookiecutter.json' # Do not run .NET CI after editing cookiecutter.json (project setup in progress)
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'cookiecutter.json' # Do not run .NET CI after editing cookiecutter.json (project setup in progress)
 
 defaults:
   run:
@@ -18,21 +14,34 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        arch: [x64]
+        include:
+          - os: macos-latest
+            arch: arm64
+    runs-on: ${{ matrix.os }}
     steps:
-    - name: 📝 Fetch Sources
-      uses: actions/checkout@v3
-    - name: 🛠 Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 8.0.x
-    - name: 🏗 Restore dependencies
-      run: dotnet restore
-    - name: 🏗 Build
-      run: dotnet build --no-restore
-    - name: 📝 Test ChromeProtocol.Core
-      run: dotnet test --no-build --verbosity normal ChromeProtocol.Core.Tests
-    - name: 📝 Test ChromeProtocol.Runtime
-      run: dotnet test --no-build --verbosity normal ChromeProtocol.Runtime.Tests
-    - name: 📝 Test ChromeProtocol.Tools
-      run: dotnet test --no-build --verbosity normal ChromeProtocol.Tools.Tests
+      - name: 📝 Fetch Sources
+        uses: actions/checkout@v3
+
+      - name: 🛠 Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+
+      - name: 🏗 Restore dependencies
+        run: dotnet restore
+
+      - name: 🏗 Build
+        run: dotnet build --no-restore
+
+      - name: 📝 Test ChromeProtocol.Core
+        run: dotnet test --no-build --verbosity normal ChromeProtocol.Core.Tests
+
+      - name: 📝 Test ChromeProtocol.Runtime
+        run: dotnet test --no-build --verbosity normal ChromeProtocol.Runtime.Tests
+
+      - name: 📝 Test ChromeProtocol.Tools
+        run: dotnet test --no-build --verbosity normal ChromeProtocol.Tools.Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,13 @@ name: Build and Test
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - 'cookiecutter.json' # Do not run .NET CI after editing cookiecutter.json (project setup in progress)
   pull_request:
+    branches:
+      - main
     paths-ignore:
       - 'cookiecutter.json' # Do not run .NET CI after editing cookiecutter.json (project setup in progress)
 


### PR DESCRIPTION
- Run CI only on `main` commits or PRs into `main`
- Introduce Dependabot
- Introduce matrix OS execution