### PR TITLE
Fix pending WebSocket protocol commands on disconnect

### DIFF
--- a/src/ChromeProtocol.Runtime.Tests/Protocol/CloseConnectionCommand.cs
+++ b/src/ChromeProtocol.Runtime.Tests/Protocol/CloseConnectionCommand.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+using ChromeProtocol.Core;
+
+namespace ChromeProtocol.Runtime.Tests.Protocol;
+
+[MethodName("CloseConnection")]
+public class CloseConnectionCommand : ICommand<CloseConnectionResult>
+{
+  [JsonIgnore]
+  public string MethodName => "CloseConnection";
+}
+
+public record CloseConnectionResult : IType;

--- a/src/ChromeProtocol.Runtime.Tests/Protocol/NeverRespondCommand.cs
+++ b/src/ChromeProtocol.Runtime.Tests/Protocol/NeverRespondCommand.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+using ChromeProtocol.Core;
+
+namespace ChromeProtocol.Runtime.Tests.Protocol;
+
+[MethodName("NeverRespond")]
+public class NeverRespondCommand : ICommand<NeverRespondResult>
+{
+  [JsonIgnore]
+  public string MethodName => "NeverRespond";
+}
+
+public record NeverRespondResult : IType;

--- a/src/ChromeProtocol.Runtime.Tests/Protocol/TestServer/WebSocketController.cs
+++ b/src/ChromeProtocol.Runtime.Tests/Protocol/TestServer/WebSocketController.cs
@@ -33,7 +33,8 @@ public class WebSocketController : ControllerBase
 
     while (!receiveResult.CloseStatus.HasValue)
     {
-      await ProcessMessage(webSocket, new ArraySegment<byte>(buffer, 0, receiveResult.Count)).ConfigureAwait(false);
+      if (!await ProcessMessage(webSocket, new ArraySegment<byte>(buffer, 0, receiveResult.Count)).ConfigureAwait(false))
+        return;
 
       receiveResult = await webSocket.ReceiveAsync(
         new ArraySegment<byte>(buffer), token);
@@ -45,7 +46,7 @@ public class WebSocketController : ControllerBase
       token).ConfigureAwait(false);
   }
 
-  static async Task ProcessMessage(WebSocket webSocket, ArraySegment<byte> incoming)
+  static async Task<bool> ProcessMessage(WebSocket webSocket, ArraySegment<byte> incoming)
   {
     var message = JsonSerializer.Deserialize<ProtocolRequest<JsonObject>>(Encoding.UTF8.GetString(incoming.ToArray()), JsonProtocolSerialization.Settings)
                   ?? throw new NotImplementedException();
@@ -56,21 +57,32 @@ public class WebSocketController : ControllerBase
         var result = new EchoResult(message.Params["message"]?.Deserialize<string>() ?? throw new NotImplementedException());
         var response = new ProtocolResponse<EchoResult>(message.Id, result, null);
         await Send(webSocket, response).ConfigureAwait(false);
-        break;
+        return true;
       }
       case "AlwaysError":
       {
         var response = new ProtocolResponse<object>(message.Id, null, new ProtocolErrorInfo(-1, null, "I'm always failing", null));
         await Send(webSocket, response).ConfigureAwait(false);
-        break;
+        return true;
       }
       case "TriggerEvent":
       {
         var response = new ProtocolEvent<EventTriggeredEvent>("EventTriggered", new EventTriggeredEvent());
         await Send(webSocket, response).ConfigureAwait(false);
-        break;
+        return true;
+      }
+      case "NeverRespond":
+      {
+        return true;
+      }
+      case "CloseConnection":
+      {
+        await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by test server", CancellationToken.None).ConfigureAwait(false);
+        return false;
       }
     }
+
+    return true;
   }
 
   private static async Task Send(WebSocket webSocket, IProtocolMessage message)

--- a/src/ChromeProtocol.Runtime.Tests/WebSocketProtocolClientTests.cs
+++ b/src/ChromeProtocol.Runtime.Tests/WebSocketProtocolClientTests.cs
@@ -48,6 +48,71 @@ public class WebSocketProtocolClientTests : IAsyncLifetime
   }
 
   [Fact]
+  public async Task SendCommandAsync_CanceledWhileWaitingForResponse_ShouldCancel()
+  {
+    var tokenSource = new CancellationTokenSource(30_0000);
+    await using var factory = TestServerFactory.CreateTestServer<Program>();
+    using var client = await CreateServerClient(factory.Server, tokenSource.Token).ConfigureAwait(false);
+    using var commandTokenSource = new CancellationTokenSource();
+
+    var command = client.SendCommandAsync(new NeverRespondCommand(), token: commandTokenSource.Token);
+    commandTokenSource.CancelAfter(100);
+
+    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await command.ConfigureAwait(false)).ConfigureAwait(false);
+  }
+
+  [Fact]
+  public async Task SendCommandAsync_ConnectionClosedWhileWaitingForResponse_ShouldFail()
+  {
+    var tokenSource = new CancellationTokenSource(30_0000);
+    await using var factory = TestServerFactory.CreateTestServer<Program>();
+    using var client = await CreateServerClient(factory.Server, tokenSource.Token).ConfigureAwait(false);
+
+    await Assert.ThrowsAsync<ProtocolConnectionClosedException>(
+      async () => await client.SendCommandAsync(new CloseConnectionCommand(), token: tokenSource.Token).ConfigureAwait(false)).ConfigureAwait(false);
+  }
+
+  [Fact]
+  public async Task SendCommandAsync_AfterConnectionClosed_ShouldFail()
+  {
+    var tokenSource = new CancellationTokenSource(30_0000);
+    await using var factory = TestServerFactory.CreateTestServer<Program>();
+    using var client = await CreateServerClient(factory.Server, tokenSource.Token).ConfigureAwait(false);
+
+    await Assert.ThrowsAsync<ProtocolConnectionClosedException>(
+      async () => await client.SendCommandAsync(new CloseConnectionCommand(), token: tokenSource.Token).ConfigureAwait(false)).ConfigureAwait(false);
+
+    await Assert.ThrowsAsync<ObjectDisposedException>(
+      async () => await client.SendCommandAsync(new EchoCommand("Hello"), token: tokenSource.Token).ConfigureAwait(false)).ConfigureAwait(false);
+  }
+
+  [Fact]
+  public async Task SendCommandAsync_DisposedWhileWaitingForResponse_ShouldFail()
+  {
+    var tokenSource = new CancellationTokenSource(30_0000);
+    await using var factory = TestServerFactory.CreateTestServer<Program>();
+    using var client = await CreateServerClient(factory.Server, tokenSource.Token).ConfigureAwait(false);
+
+    var command = client.SendCommandAsync(new NeverRespondCommand(), token: tokenSource.Token);
+    client.Dispose();
+
+    await Assert.ThrowsAsync<ObjectDisposedException>(async () => await command.ConfigureAwait(false)).ConfigureAwait(false);
+  }
+
+  [Fact]
+  public async Task SendCommandAsync_AfterDisposed_ShouldFail()
+  {
+    var tokenSource = new CancellationTokenSource(30_0000);
+    await using var factory = TestServerFactory.CreateTestServer<Program>();
+    using var client = await CreateServerClient(factory.Server, tokenSource.Token).ConfigureAwait(false);
+
+    client.Dispose();
+
+    await Assert.ThrowsAsync<ObjectDisposedException>(
+      async () => await client.SendCommandAsync(new EchoCommand("Hello"), token: tokenSource.Token).ConfigureAwait(false)).ConfigureAwait(false);
+  }
+
+  [Fact]
   public async Task FireCommandAsync_TriggerEvent_ShouldSendEventBack()
   {
     var tokenSource = new CancellationTokenSource(30_0000);

--- a/src/ChromeProtocol.Runtime.Tests/WebSocketProtocolClientTests.cs
+++ b/src/ChromeProtocol.Runtime.Tests/WebSocketProtocolClientTests.cs
@@ -73,6 +73,29 @@ public class WebSocketProtocolClientTests : IAsyncLifetime
   }
 
   [Fact]
+  public async Task SendCommandAsync_MultiplePendingCommandsWhenConnectionClosed_ShouldFailWithDifferentExceptions()
+  {
+    var tokenSource = new CancellationTokenSource(30_0000);
+    await using var factory = TestServerFactory.CreateTestServer<Program>();
+    using var client = await CreateServerClient(factory.Server, tokenSource.Token).ConfigureAwait(false);
+
+    var firstCommand = client.SendCommandAsync(new NeverRespondCommand(), token: tokenSource.Token);
+    var secondCommand = client.SendCommandAsync(new NeverRespondCommand(), token: tokenSource.Token);
+    var closeCommand = client.SendCommandAsync(new CloseConnectionCommand(), token: tokenSource.Token);
+
+    var firstException = await Assert.ThrowsAsync<ProtocolConnectionClosedException>(
+      async () => await firstCommand.ConfigureAwait(false)).ConfigureAwait(false);
+    var secondException = await Assert.ThrowsAsync<ProtocolConnectionClosedException>(
+      async () => await secondCommand.ConfigureAwait(false)).ConfigureAwait(false);
+    var closeException = await Assert.ThrowsAsync<ProtocolConnectionClosedException>(
+      async () => await closeCommand.ConfigureAwait(false)).ConfigureAwait(false);
+
+    Assert.NotSame(firstException, secondException);
+    Assert.NotSame(firstException, closeException);
+    Assert.NotSame(secondException, closeException);
+  }
+
+  [Fact]
   public async Task SendCommandAsync_AfterConnectionClosed_ShouldFail()
   {
     var tokenSource = new CancellationTokenSource(30_0000);

--- a/src/ChromeProtocol.Runtime/Messaging/ProtocolConnectionClosedException.cs
+++ b/src/ChromeProtocol.Runtime/Messaging/ProtocolConnectionClosedException.cs
@@ -1,0 +1,34 @@
+namespace ChromeProtocol.Runtime.Messaging;
+
+/// <summary>
+/// Represents a protocol command failure caused by the underlying connection closing before a response is received.
+/// </summary>
+public class ProtocolConnectionClosedException : Exception
+{
+  /// <summary>
+  /// Initializes a new instance of the <see cref="ProtocolConnectionClosedException"/> class.
+  /// </summary>
+  public ProtocolConnectionClosedException()
+    : this("The protocol connection was closed before a response was received.")
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="ProtocolConnectionClosedException"/> class with a specified error message.
+  /// </summary>
+  /// <param name="message">The message that describes the error.</param>
+  public ProtocolConnectionClosedException(string message)
+    : base(message)
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="ProtocolConnectionClosedException"/> class with a specified error message and inner exception.
+  /// </summary>
+  /// <param name="message">The message that describes the error.</param>
+  /// <param name="innerException">The exception that is the cause of the current exception.</param>
+  public ProtocolConnectionClosedException(string message, Exception innerException)
+    : base(message, innerException)
+  {
+  }
+}

--- a/src/ChromeProtocol.Runtime/Messaging/WebSockets/WebSocketProtocolClient.cs
+++ b/src/ChromeProtocol.Runtime/Messaging/WebSockets/WebSocketProtocolClient.cs
@@ -78,7 +78,7 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
     }
     finally
     {
-      Dispose();
+      Close(new ProtocolConnectionClosedException());
 
       if (!_connectionCancellation?.IsCancellationRequested ?? false)
         OnDisconnected?.Invoke(this, EventArgs.Empty);
@@ -118,30 +118,52 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
     string? sessionId = null,
     CancellationToken? token = default) where TResponse : IType
   {
+    var cancellationToken = token ?? CancellationToken.None;
+    cancellationToken.ThrowIfCancellationRequested();
+    ThrowIfDisposed();
+
     var id = Interlocked.Increment(ref _currentId);
     try
     {
-      var resolver = new TaskCompletionSource<JsonObject>();
+      var resolver = new TaskCompletionSource<JsonObject>(TaskCreationOptions.RunContinuationsAsynchronously);
       if (_responseResolvers.TryAdd(id, resolver))
       {
-        await FireInternalAsync(id, GetMethodName(command.GetType()), command, sessionId).ConfigureAwait(false);
-        var responseRaw = await resolver.Task.ConfigureAwait(false);
-        var response = responseRaw.Deserialize<TResponse>(JsonProtocolSerialization.Settings) ?? throw new ArgumentException(null, nameof(responseRaw));
-        return response;
+        using (cancellationToken.Register(() =>
+               {
+                 if (_responseResolvers.TryRemove(id, out var pendingResolver))
+                   pendingResolver.TrySetCanceled();
+               }))
+        {
+          await FireInternalAsync(id, GetMethodName(command.GetType()), command, sessionId).ConfigureAwait(false);
+          var responseRaw = await resolver.Task.ConfigureAwait(false);
+          var response = responseRaw.Deserialize<TResponse>(JsonProtocolSerialization.Settings) ?? throw new ArgumentException(null, nameof(responseRaw));
+          return response;
+        }
       }
 
       throw new Exception();
     }
-    catch (Exception e)
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+      throw;
+    }
+    catch (Exception e) when (e is not ProtocolConnectionClosedException and not ObjectDisposedException)
     {
       _logger.LogError(e, "Error occured while sending the protocol message");
       throw;
+    }
+    finally
+    {
+      _responseResolvers.TryRemove(id, out _);
     }
   }
 
   public async Task FireCommandAsync(ICommand command, string? sessionId = default,
     CancellationToken token = default)
   {
+    token.ThrowIfCancellationRequested();
+    ThrowIfDisposed();
+
     var id = Interlocked.Increment(ref _currentId);
     await FireInternalAsync(id, GetMethodName(command.GetType()), command, sessionId).ConfigureAwait(false);
   }
@@ -150,19 +172,41 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
 
   public void Dispose()
   {
-    if (_isDisposed) return;
-    if (_connectionCancellation?.IsCancellationRequested ?? false) return;
+    Close(new ObjectDisposedException(GetType().FullName));
+  }
 
-    _connectionCancellation?.Cancel();
+  private void Close(Exception pendingResponseException)
+  {
+    if (_isDisposed) return;
+
     _isDisposed = true;
+
+    if (!(_connectionCancellation?.IsCancellationRequested ?? false))
+      _connectionCancellation?.Cancel();
+
+    if (!_outgoingMessages.IsAddingCompleted)
+      _outgoingMessages.CompleteAdding();
+
+    FailPendingResponses(pendingResponseException);
   }
 
   private async Task FireInternalAsync(int id, string methodName, ICommand command, string? sessionId)
   {
+    ThrowIfDisposed();
+
     var request = new ProtocolRequest<ICommand>(id, methodName, command, sessionId);
-    if (!_outgoingMessages.TryAdd(request))
+    try
     {
-      throw new Exception("Can't schedule outgoing event for sending.");
+      if (!_outgoingMessages.TryAdd(request))
+      {
+        ThrowIfDisposed();
+        throw new Exception("Can't schedule outgoing event for sending.");
+      }
+    }
+    catch (InvalidOperationException)
+    {
+      ThrowIfDisposed();
+      throw;
     }
   }
 
@@ -215,6 +259,13 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
             incoming = _nativeClient.ReceiveAsync(new ArraySegment<byte>(buffer), token).ConfigureAwait(false)
               .GetAwaiter().GetResult();
 
+            if (incoming.MessageType == WebSocketMessageType.Close)
+            {
+              _logger.LogWarning($"Chrome has closed the WebSocket connection during receive operation. Socket state: {_nativeClient.State}");
+              DisconnectAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+              return;
+            }
+
             memoryStream.Write(buffer, 0, incoming.Count);
           } while (!incoming.EndOfMessage);
 
@@ -236,6 +287,7 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
       catch (Exception e)
       {
         _logger.LogError(e, "Error occured while receiving the protocol message");
+        FailPendingResponses(new ProtocolConnectionClosedException("The protocol connection failed while receiving a message.", e));
         throw;
       }
     }).Start();
@@ -272,10 +324,10 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
     _responseResolvers.TryRemove(response.Id, out var resolver);
 
     if (response.Error is { } error)
-      resolver?.SetException(new ProtocolErrorException(error));
+      resolver?.TrySetException(new ProtocolErrorException(error));
 
     if (response.Result is { } result)
-      resolver?.SetResult(result);
+      resolver?.TrySetResult(result);
   }
 
   private async Task ProcessOutgoingRequest(ProtocolRequest<ICommand> request)
@@ -292,6 +344,21 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
       await DisconnectAsync(CancellationToken.None).ConfigureAwait(false);
     }
     OnRequestSent?.Invoke(this, request);
+  }
+
+  private void FailPendingResponses(Exception exception)
+  {
+    foreach (var pendingResponse in _responseResolvers.ToArray())
+    {
+      if (_responseResolvers.TryRemove(pendingResponse.Key, out var resolver))
+        resolver.TrySetException(exception);
+    }
+  }
+
+  private void ThrowIfDisposed()
+  {
+    if (_isDisposed)
+      throw new ObjectDisposedException(GetType().FullName);
   }
 
   private static string GetMethodName(MemberInfo type) =>

--- a/src/ChromeProtocol.Runtime/Messaging/WebSockets/WebSocketProtocolClient.cs
+++ b/src/ChromeProtocol.Runtime/Messaging/WebSockets/WebSocketProtocolClient.cs
@@ -78,7 +78,7 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
     }
     finally
     {
-      Close(new ProtocolConnectionClosedException());
+      Close(() => new ProtocolConnectionClosedException());
 
       if (!_connectionCancellation?.IsCancellationRequested ?? false)
         OnDisconnected?.Invoke(this, EventArgs.Empty);
@@ -128,17 +128,16 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
       var resolver = new TaskCompletionSource<JsonObject>(TaskCreationOptions.RunContinuationsAsynchronously);
       if (_responseResolvers.TryAdd(id, resolver))
       {
-        using (cancellationToken.Register(() =>
-               {
-                 if (_responseResolvers.TryRemove(id, out var pendingResolver))
-                   pendingResolver.TrySetCanceled();
-               }))
+        using var _ = cancellationToken.Register(() =>
         {
-          await FireInternalAsync(id, GetMethodName(command.GetType()), command, sessionId).ConfigureAwait(false);
-          var responseRaw = await resolver.Task.ConfigureAwait(false);
-          var response = responseRaw.Deserialize<TResponse>(JsonProtocolSerialization.Settings) ?? throw new ArgumentException(null, nameof(responseRaw));
-          return response;
-        }
+          if (_responseResolvers.TryRemove(id, out var pendingResolver))
+            pendingResolver.TrySetCanceled();
+        });
+
+        await FireInternalAsync(id, GetMethodName(command.GetType()), command, sessionId).ConfigureAwait(false);
+        var responseRaw = await resolver.Task.ConfigureAwait(false);
+        var response = responseRaw.Deserialize<TResponse>(JsonProtocolSerialization.Settings) ?? throw new ArgumentException(null, nameof(responseRaw));
+        return response;
       }
 
       throw new Exception();
@@ -172,10 +171,10 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
 
   public void Dispose()
   {
-    Close(new ObjectDisposedException(GetType().FullName));
+    Close(() => new ObjectDisposedException(GetType().FullName));
   }
 
-  private void Close(Exception pendingResponseException)
+  private void Close(Func<Exception> pendingResponseExceptionFactory)
   {
     if (_isDisposed) return;
 
@@ -187,7 +186,7 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
     if (!_outgoingMessages.IsAddingCompleted)
       _outgoingMessages.CompleteAdding();
 
-    FailPendingResponses(pendingResponseException);
+    FailPendingResponses(pendingResponseExceptionFactory);
   }
 
   private async Task FireInternalAsync(int id, string methodName, ICommand command, string? sessionId)
@@ -287,7 +286,7 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
       catch (Exception e)
       {
         _logger.LogError(e, "Error occured while receiving the protocol message");
-        FailPendingResponses(new ProtocolConnectionClosedException("The protocol connection failed while receiving a message.", e));
+        FailPendingResponses(() => new ProtocolConnectionClosedException("The protocol connection failed while receiving a message.", e));
         throw;
       }
     }).Start();
@@ -346,12 +345,12 @@ public class WebSocketProtocolClient<TNativeClient> : IProtocolClient
     OnRequestSent?.Invoke(this, request);
   }
 
-  private void FailPendingResponses(Exception exception)
+  private void FailPendingResponses(Func<Exception> exceptionFactory)
   {
     foreach (var pendingResponse in _responseResolvers.ToArray())
     {
       if (_responseResolvers.TryRemove(pendingResponse.Key, out var resolver))
-        resolver.TrySetException(exception);
+        resolver.TrySetException(exceptionFactory());
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes `WebSocketProtocolClient.SendCommandAsync` hanging indefinitely when the underlying WebSocket connection is closed before a command response is received.

## Changes

- Complete pending command response tasks when the protocol connection is closed.
- Honor `CancellationToken` while waiting for command responses.
- Prevent new commands from being queued after the client has been disposed.
- Add regression tests for cancellation, connection close, and post-dispose command calls.